### PR TITLE
Use a version range for the AsciidoctorJ dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  build:
+  default-asciidoctorj-version:
     docker:
       - image: circleci/openjdk:8-jdk
 
@@ -16,14 +16,27 @@ jobs:
             - gradle-{{ checksum "build.gradle" }}
             - gradle-
 
-      - run: ./gradlew dependencies
+      - run: ./gradlew check
 
       - save_cache:
           paths:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle" }}
 
-      - run: ./gradlew check
+      - run:
+          name: Ensure no uncommitted changes
+          command: |
+            if [ -n "$(git status --porcelain)" ]; then
+                echo "There are uncommitted changes in working tree after execution of the build"
+                echo "Perform git diff"
+                git --no-pager diff
+                echo "Perform git status"
+                git status
+                echo "Please run the build locally and commit changes"
+                exit 1
+            else
+                echo "Git working tree is clean"
+            fi
 
       - run:
           name: Save test results
@@ -34,6 +47,55 @@ jobs:
 
       - store_test_results:
           path: ~/test-results
+          when: always
 
       - store_artifacts:
           path: ~/test-results/junit
+          when: always
+
+  all-asciidoctorj-versions:
+    docker:
+      - image: circleci/openjdk:8-jdk
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - gradle-{{ checksum "build.gradle" }}
+            - gradle-
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.5.1
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.5.0
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.4.3
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.4.2
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.4.1
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.4.0
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.3.1
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.3.0
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.2.0
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.1.0
+
+      - run: ./gradlew check -PasciidoctorjVersion=2.0.0
+
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: gradle-{{ checksum "build.gradle" }}
+
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - default-asciidoctorj-version
+      - all-asciidoctorj-versions

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ java {
 }
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 
@@ -60,8 +61,10 @@ test {
     useJUnitPlatform()
 }
 
+def strictAsciidoctorjVersion = hasProperty('asciidoctorjVersion') ? '!!' + getProperty('asciidoctorjVersion') : ''
+
 dependencies {
-    implementation "org.asciidoctor:asciidoctorj:$asciidoctorjVersion"
+    implementation "org.asciidoctor:asciidoctorj:${asciidoctorjVersion}${strictAsciidoctorjVersion}"
     implementation "fr.jmini.utils:issue-model:$issueModelVersion"
     implementation "com.google.code.gson:gson:$gsonVersion"
 
@@ -108,6 +111,7 @@ publishing {
 nexusPublishing {
     repositories {
         sonatype {
+            packageGroup = 'fr.jmini'
             username = project.findProperty('sonatypeUser') ?: ''
             password = project.findProperty('sonatypePassword') ?: ''
         }
@@ -129,7 +133,7 @@ configurations {
 }
 
 asciidoctorj {
-    version = "$asciidoctorjVersion"
+    version = '2.2.0'
 }
 
 asciidoctor {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=2.0.1-SNAPSHOT
 lastVersion=2.0.0
 
-asciidoctorjVersion=2.2.0
+asciidoctorjVersion=[2.0.0, 3.0.0[
 assertjVersion=3.11.1
 junitVersion=5.7.1
 issueModelVersion=1.0.0

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -28,7 +28,9 @@ For example the Jenkins link:https://wiki.jenkins.io/x/1YTeCQ[Warnings Next Gene
 
 === AsciidoctorJ version
 
-The latest version of this extension is built and tested with version `{asciidoctorj-version}` of `org.asciidoctor:asciidoctorj`.
+This extension is compatible with `org.asciidoctor:asciidoctorj` in range `{asciidoctorj-version}`.
+
+The continuous integration server runs the test suite with different AsciidoctorJ versions within this range.
 
 == Usage
 


### PR DESCRIPTION
Instead of defining a specific AsciidoctorJ version as dependency, a range is now used.

The strict AsciidoctorJ version can be controlled with the `asciidoctorjVersion` parameter.

Example:

```
./gradlew build -PasciidoctorjVersion=2.2.0
```

CircleCI is configured to test all the AsciidoctorJ within this range.
